### PR TITLE
SVG service should escape HTML in Mermaid node texts

### DIFF
--- a/src/app/components/calculated-static-svg/calculated-static-svg.component.ts
+++ b/src/app/components/calculated-static-svg/calculated-static-svg.component.ts
@@ -1,5 +1,6 @@
 import { Component, ElementRef, Input } from '@angular/core';
 import { Mermaid2svgService } from '../../services/mermaid2svg.service';
+import { escapeHtml } from '../../util/util';
 
 @Component({
   selector: 'app-calculated-static-svg',
@@ -60,13 +61,9 @@ export class CalculatedStaticSvgComponent {
 
   showSvg(svg: string) {
     if (this._show === CalculatedStaticSvgComponent.SHOW_TEXT) {
-      this.rootElement.nativeElement.innerHTML = '<pre><code>' + htmlEscape(svg) + '</code></pre>'
+      this.rootElement.nativeElement.innerHTML = '<pre><code>' + escapeHtml(svg) + '</code></pre>'
     } else {
       this.rootElement.nativeElement.innerHTML = svg
     }
   }
 }
-
-function htmlEscape(s: string): string {
-  return s.replaceAll('<', '&lt;').replaceAll('>', '&gt;')
-} 

--- a/src/app/graphics/svg-generator.ts
+++ b/src/app/graphics/svg-generator.ts
@@ -1,4 +1,5 @@
 import { CreationReason } from "../model/horizontalGrouping"
+import { escapeHtml } from "../util/util"
 import { Layout, PlacedEdge, PlacedNode } from "./edge-layout"
 
 export function generateSvg(layout: Layout) {
@@ -65,7 +66,7 @@ function renderOriginalNode(n: PlacedNode): string {
       x="${n.horizontalBox.center}"
       y="${n.verticalBox.center}"
       text-anchor="middle" dominant-baseline="middle" class="nodeText">
-        ${n.text}
+        ${escapeHtml(n.text)}
     </text>
   </g>
 `

--- a/src/app/services/mermaid2svg.service.spec.ts
+++ b/src/app/services/mermaid2svg.service.spec.ts
@@ -1,7 +1,7 @@
 import { Mermaid2svgService } from './mermaid2svg.service';
 import { OurMermaid2SvgDimensions } from '../app.module'
 
-describe('Mermaid2svgService', () => {
+describe('Mermaid2svgService - please maintain this test using the GUI', () => {
   let service: Mermaid2svgService;
 
   beforeEach(() => {
@@ -9,7 +9,7 @@ describe('Mermaid2svgService', () => {
     service = new Mermaid2svgService(new OurMermaid2SvgDimensions())
   });
 
-  it('Please maintain this test using the GUI', () => {
+  it('Simple', () => {
     const input = `Start("My start"):::normal
 N1("Node 1"):::normal
 N2("Node 2"):::normal
@@ -86,6 +86,145 @@ N1 --> |success| N2`
       y="145"
       text-anchor="middle" dominant-baseline="middle" class="nodeText">
         Node 1
+    </text>
+  </g>
+  <g class="frank-flowchart-node-N2">
+    <rect class="rectangle"
+      x="20"
+      y="245"
+      width="110"
+      height="40"
+      rx="5">
+    </rect>
+    <text
+      x="75"
+      y="265"
+      text-anchor="middle" dominant-baseline="middle" class="nodeText">
+        Node 2
+    </text>
+  </g>
+  <g class="frank-flowchart-node-End">
+    <rect class="rectangle"
+      x="65"
+      y="365"
+      width="110"
+      height="40"
+      rx="5">
+    </rect>
+    <text
+      x="120"
+      y="385"
+      text-anchor="middle" dominant-baseline="middle" class="nodeText">
+        End node
+    </text>
+  </g>
+  <g class="frank-flowchart-edge-Start-N1">
+    <polyline class="line" points="89,44 60,125" marker-end="url(#arrow)"/>
+  </g>
+  <g class="frank-flowchart-edge-Start-intermediate1">
+    <polyline class="line" points="121,44 150,145" />
+  </g>
+  <g class="frank-flowchart-edge-intermediate1-N2">
+    <polyline class="line" points="150,145 91,245" marker-end="url(#arrow)"/>
+  </g>
+  <g class="frank-flowchart-edge-N1-intermediate2">
+    <polyline class="line error" points="76,164 165,265" />
+  </g>
+  <g class="frank-flowchart-edge-intermediate2-End">
+    <polyline class="line error" points="165,265 136,365" marker-end="url(#arrow)"/>
+  </g>
+  <g class="frank-flowchart-edge-N2-End">
+    <polyline class="line" points="75,284 104,365" marker-end="url(#arrow)"/>
+  </g>
+  <g class="frank-flowchart-edge-N1-N2">
+    <polyline class="line" points="44,164 59,245" marker-end="url(#arrow)"/>
+  </g>
+</svg>`
+    expect(service.mermaid2svg(input).split('\n')).toEqual(expected!.split('\n'))
+  })
+
+  it('Should escape HTML in node texts', () => {
+    const input = `Start("<b>My start</b>"):::normal
+N1("<b>Node 1</b>"):::normal
+N2("Node 2"):::normal
+End("End node"):::normal
+Start --> |success| N1
+Start --> |success| N2
+N1 --> |error| End
+N2 --> |success| End
+N1 --> |success| N2`
+
+    // In the GUI, enter the above Mermaid text. Then look at the bottom
+    // under the heading "Static SVG". If that image looks good, copy
+    // the text next to the static SVG here.
+    //
+    // VS Code trick: VS Code may add too many or too few leading spaces
+    // to each line. Fix this by finding the right indent of the line
+    // "const expected = ``" before inserting the text inside the ``.
+    //
+    // About escaped HTML. If the nodes contain HTML tags, the '<' and '>'
+    // characters are replaced by '&lt;' and '&gt;'. When you copy/paste
+    // as explained, you paste the unescaped '<' and '>' characters. Please
+    // correct after pasting.
+    const expected = `<svg class="svg" xmlns="http://www.w3.org/2000/svg"
+  width="195" height="480" >
+  <defs>
+    <style>
+      .rectangle {
+        fill: transparent;
+        stroke: black;
+        stroke-width: 3;
+      }
+    
+      .line {
+        stroke: black;
+        stroke-width: 3;
+      }
+
+      .line.error {
+        stroke: red
+      }
+    </style>
+    <!-- A marker to be used as an arrowhead -->
+    <marker
+      id="arrow"
+      viewBox="0 0 4 4"
+      refX="4"
+      refY="2"
+      markerWidth="4"
+      markerHeight="4"
+      orient="auto-start-reverse">
+      <path d="M 0 0 L 4 2 L 0 4 z" />
+    </marker>
+  </defs>
+  <g class="frank-flowchart-node-Start">
+    <rect class="rectangle"
+      x="50"
+      y="5"
+      width="110"
+      height="40"
+      rx="5">
+    </rect>
+    <text
+      x="105"
+      y="25"
+      text-anchor="middle" dominant-baseline="middle" class="nodeText">
+        &lt;b&gt;My start&lt;/b&gt;
+    </text>
+  </g>
+  <g class="frank-flowchart-node-N1">
+    <rect class="rectangle"
+      x="5"
+      y="125"
+      width="110"
+      height="40"
+      rx="5">
+    </rect>
+    <text
+      x="60"
+      y="145"
+      text-anchor="middle" dominant-baseline="middle" class="nodeText">
+        &lt;b&gt;Node 1&lt;/b&gt;
     </text>
   </g>
   <g class="frank-flowchart-node-N2">

--- a/src/app/util/util.spec.ts
+++ b/src/app/util/util.spec.ts
@@ -1,4 +1,4 @@
-import { doRotateToSwapItems, getRange, rotateToSwapItems, roundedMedian, sortedUniqNumbers } from './util'
+import { doRotateToSwapItems, getRange, escapeHtml, rotateToSwapItems, roundedMedian, sortedUniqNumbers } from './util'
 
 describe('Util test', () => {
   it('Get range', () => {
@@ -113,5 +113,9 @@ describe('Util test', () => {
     expect(permutation[2]).toEqual(3)
     expect(permutation[3]).toEqual(1)
     expect(permutation[4]).toEqual(4)
+  })
+
+  it('escapeHtml', () => {
+    expect(escapeHtml('<h1>Title</h1>')).toEqual('&lt;h1&gt;Title&lt;/h1&gt;')
   })
 })

--- a/src/app/util/util.ts
+++ b/src/app/util/util.ts
@@ -77,3 +77,7 @@ export function doRotateToSwapItems<T>(target: T[], posFrom: number, posTo: numb
   }
   target[posTo] = carry
 }
+
+export function escapeHtml(s: string): string {
+  return s.replaceAll('<', '&lt;').replaceAll('>', '&gt;')
+} 


### PR DESCRIPTION
If Mermaid nodes contain HTML, it should be escaped. The static SVG is then rendered like this:

![image](https://github.com/frankframework/frank-config-layout/assets/6784732/4eb5f34d-7427-4c59-ba1e-241b1cdff42a)
